### PR TITLE
Updated README to include rationale and deliverables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Reporting Guidelines and Enforcement Guidelines Task Force Charter
 
 __Context__  
-In the last year, incidents surrounding [The Carpentries Code of Conduct (CoC)](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) highlighted issues with enforcing the CoC and adjudicating reported CoC violations. As a result, and due to Software and Data Carpentry having merged to form The Carpentries, there have been updates to governance and policy documents, including [updates to the Code of Conduct](https://carpentries.org/blog/2018/09/coc-revision-release/).
+In the last year, incidents surrounding [The Carpentries Code of Conduct (CoC)](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) highlighted issues with enforcing the CoC and adjudicating reported CoC violations. As a result, and due to multiple Lesson Programs (Software Carpentry, Data Carpentry and Library Carpentry) becoming The Carpentries, there have been updates to governance and policy documents, including [updates to the Code of Conduct](https://carpentries.org/blog/2018/09/coc-revision-release/).
 
 Updates to the CoC were segmented in three parts: 1) The Carpentries Code of Conduct, 2) Incident Reporting Guidelines, and 3) Enforcement Manual. The process of updating 1) and 2) took five months (from April 2018 through September 2018)
 
@@ -13,7 +13,7 @@ Since completion of the CoC update, there have been two CoC incidents reported.
 
 For more information, see the [Code of Conduct Transparency Report](https://github.com/carpentries/executive-council-info/blob/master/code-of-conduct-transparency-reports/2018-11-09-coc-transparency-report.md).
 
-These two incidents were assessed under the current enforcement manual, which prevented the committee from arriving at a resolution swiftly. The Executive Council has expressed concern with the lack of timeliness as it relates to resolving CoC incident reports. The CoC Committee serves to respond and resolve CoC incident reports, and update documentation. Though work has been completed to update our Code of Conduct, the CoC committee lacks the expertise to update the reporting guidelines and enforcement manual. Such updates include, but are not limited to: 
+These two incidents were assessed under the current enforcement manual, which prevented the committee from arriving at a resolution swiftly. The Executive Council has expressed concern with the lack of timeliness as it relates to resolving CoC incident reports. The CoC Committee serves to respond and resolve CoC incident reports, and update documentation. Though work has been completed to update our Code of Conduct, the CoC committee could use additional expertise to update the reporting guidelines and enforcement manual. Such updates include, but are not limited to: 
 
 * Receiving a report (via a secure form)
 * Handling a report (in terms of data storage, meetings, etc.)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# -coc-guidelines-taskforce
-Repository to update the Enforcement Manual and Reporting Guidelines for The Carpentries Code of Conduct.
+# The Carpentries Code of Conduct 
+## Reporting Guidelines and Enforcement Guidelines Task Force Charter
+
+__Context__  
+In the last year, incidents surrounding [The Carpentries Code of Conduct (CoC)](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) highlighted issues with enforcing the CoC and adjudicating reported CoC violations. As a result, and due to Software and Data Carpentry having merged to form The Carpentries, there have been updates to governance and policy documents, including [updates to the Code of Conduct](https://carpentries.org/blog/2018/09/coc-revision-release/).
+
+Updates to the CoC were segmented in three parts: 1) The Carpentries Code of Conduct, 2) Incident Reporting Guidelines, and 3) Enforcement Manual. The process of updating 1) and 2) took five months (from April 2018 through September 2018)
+
+Since completion of the CoC update, there have been two CoC incidents reported.
+
+* __Incident #1:__ Reported 2018-09-07, Resolved 2018-10-17 
+* __Incident #2:__ Reported 2018-09-27, Resolved 2018-10-19
+
+For more information, see the [Code of Conduct Transparency Report](https://github.com/carpentries/executive-council-info/blob/master/code-of-conduct-transparency-reports/2018-11-09-coc-transparency-report.md).
+
+These two incidents were assessed under the current enforcement manual, which prevented the committee from arriving at a resolution swiftly. The Executive Council has expressed concern with the lack of timeliness as it relates to resolving CoC incident reports. The CoC Committee serves to respond and resolve CoC incident reports, and update documentation. Though work has been completed to update our Code of Conduct, the CoC committee lacks the expertise to update the reporting guidelines and enforcement manual. Such updates include, but are not limited to: 
+
+* Receiving a report (via a secure form)
+* Handling a report (in terms of data storage, meetings, etc.)
+* Resolving a report
+* Communicating about incidents
+
+__Objectives__  
+The objective of this task force is to update our Reporting Guidelines and Enforcement Manual and Guidelines and processes. We want all members of our community to understand the process, for reporters to feel safe and supported in reporting an incident and in the community, to ensure a confidential process, and for people under review to have access to a fair and unbiased review. We want to be able to handle Code of Conduct reports respectfully, in a timely manner and with appropriate communication and transparency in accordance with our Code of Conduct. A draft lists of tasks to meet our objective is as follows:
+
+1. Identify practices of organizations similar to The Carpentries for reviewing, responding to, and enforcing CoC violations.
+2. Revise The Carpentries Code of Conduct Enforcement Manual per the recommendations and [issues with implementation document](https://docs.google.com/document/d/1S_Jjh_kGaCqS9QUnzmlsKfACu3fo8yGNROUa8kTlhg0/edit?usp=sharing). 
+3. Update the Reporting Guidelines to include a secure collection method.
+4. Develop guidelines and processes about how reports are collected, stored and shared.
+5. Develop guidelines for termed suspension from The Carpentries.
+6. Develop guidelines for coaching and reinstatement to The Carpentries.
+7. Develop guidelines for termination from The Carpentries.
+8. Offer incident response protocol recommendations to the CoC Committee.
+9. Develop communication templates and guidelines for committee and incident response.
+10. Develop an appeal process.
+11. Address legal issues that may arise in code of conduct incident matters.
+12. Develop guidelines for communicating with staff and the Executive Council about CoC incidents.
+
+__Deliverables__  
+The following deliverables are the intended outcomes of this task force:
+1. Revised enforcement manual and reporting guidelines in The Carpentries handbook including update log.
+2. Blog post summary of task force meetings/discussions with release of enforcement manual and reporting guidelines.
+3. Incident response checklist to be added to The Carpentries handbook along with revised enforcement manual and reporting guidelines. 
+


### PR DESCRIPTION
@tracykteal Here is the repo where we'll work on updating the CoC reporting guidelines and enforcement manual. Please review the README and make any changes as you see fit.